### PR TITLE
Adds gulpjs documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,22 @@ Handlebars.registerPartial('link', require("./partial.hbs"));
 
 Checkout the example folder for details.
 
+### Use in gulp
+
+You can easily use hbsfy in [gulp][] with [gulp-browserify][]:
+
+```javascript
+gulp.task('js', function() {
+  gulp.src('js/app.js')
+    .pipe(browserify({
+      insertGlobals: true,
+      transform: ['hbsfy']
+    }))
+    .pipe(concat('app.js'))
+    .pipe(gulp.dest('./public/js'));
+});
+```
+
 ## Changelog
 
 ### 1.0.0
@@ -87,3 +103,5 @@ Checkout the example folder for details.
 [Handlebars]: http://handlebarsjs.com/
 [Browserify v2]: https://github.com/substack/node-browserify
 [peer dependency]: http://blog.nodejs.org/2013/02/07/peer-dependencies/
+[gulp]: http://gulpjs.com/
+[gulp-browserify]: https://github.com/deepak1556/gulp-browserify


### PR DESCRIPTION
This is probably obvious to browserify and/or gulp veterans, but it took me a while to figure this out.
