### PR TITLE
use package.json options + custom precompiler/compiler options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-[![Build Status](https://travis-ci.org/epeli/node-hbsfy.png?branch=master)](https://travis-ci.org/epeli/node-hbsfy)
+# hbsfy [![Build Status][travis-badge]][travis]
 
-# hbsfy
-
-[Handlebars][] precompiler plugin for [Browserify][] without magic.
+[Handlebars][handlebars] precompiler plugin for [Browserify][browserify] without magic.
 
 Compiles Handlebars templates to plain Javascript. The compiled templates only
 have one copy of the Handlebars runtime so they are lightweight and fast!
@@ -11,27 +9,51 @@ have one copy of the Handlebars runtime so they are lightweight and fast!
 
 Install hbsfy locally to your project:
 
-    npm install hbsfy
+```no-highlight
+npm install hbsfy --save-dev
+```
 
-Handlebars will be automatically installed as [peer dependency][].
+Handlebars will be automatically installed as a [peer dependency][peer-dep].
 
 Then use it as Browserify transform module with `-t`:
 
-    browserify -t hbsfy main.js > bundle.js
+```no-highlight
+browserify -t hbsfy main.js > bundle.js
+```
 
-where main.js can be like:
-
+where `main.js` can be like:
 
 ```javascript
 var template = require("./template.hbs");
 document.body.innerHTML = template({ name: "Epeli" });
 ```
 
-and template.hbs:
+and `template.hbs`:
 
-```html
+```hbs
 <h1>Hello {{name}}!</h1>
 ```
+
+### Specifying Options
+
+By default hbsfy uses the `package.json` in your project to set configuration options.
+
+```json
+{
+  "name": "my-project",
+  "browserify": {
+    "transform": ["hbsfy"]
+  },
+  "hbsfy": {
+    "extensions": ["html"],
+    "precompiler": "precompiler-module-name",
+    "compiler": "require('my-compiler') or window.compiler"
+  }
+}
+```
+
+All options are optional. By default `precompiler` is just `handlebars`, and `compiler` is `require('hbsfy/runtime')` which is just Handlebars.Runtime.
+These options will be used by normal usage, as well as programmatic usage. Using `hbsfy.configure` (see below) will override these options.
 
 ## Programmatic usage
 
@@ -90,6 +112,8 @@ Checkout the example folder for details.
   - Option to configure template extensions
 
 
-[Handlebars]: http://handlebarsjs.com/
-[Browserify]: https://github.com/substack/node-browserify
-[peer dependency]: http://blog.nodejs.org/2013/02/07/peer-dependencies/
+[travis]: https://travis-ci.org/epeli/node-hbsfy
+[travis-badge]: https://travis-ci.org/epeli/node-hbsfy.svg?branch=master
+[handlebars]: http://handlebarsjs.com/
+[browserify]: https://github.com/substack/node-browserify
+[peer-dep]: http://blog.nodejs.org/2013/02/07/peer-dependencies/

--- a/index.js
+++ b/index.js
@@ -1,13 +1,19 @@
 /*jshint node: true*/
+"use strict";
 
-var through = require('through');
-var Handlebars = require("handlebars");
+var through = require("through");
+var precompiler = require("handlebars");
+var compiler = "require('hbsfy/runtime')";
+var mothership = require("mothership");
 
 var extensions = {
   hbs: 1,
   handlebar: 1,
   handlebars: 1
 };
+
+// parse package.json options, stored in 'hbsfy' attribute.
+parsePackageOptions();
 
 function hbsfy(file) {
   if (!extensions[file.split(".").pop()]) return through();
@@ -18,25 +24,51 @@ function hbsfy(file) {
     buffer += chunk.toString();
   },
   function() {
-    var js = Handlebars.precompile(buffer);
+    var js = precompiler.precompile(buffer);
     // Compile only with the runtime dependency.
     var compiled = "// hbsfy compiled Handlebars template\n";
-    compiled += "var Handlebars = require('hbsfy/runtime');\n";
-    compiled += "module.exports = Handlebars.template(" + js.toString() + ");\n";
+    compiled += "var compiler = " + compiler + ";\n";
+    compiled += "module.exports = compiler.template(" + js.toString() + ");\n";
     this.queue(compiled);
     this.queue(null);
   });
-
 };
 
 hbsfy.configure = function(opts) {
   if (!opts || !opts.extensions) return hbsfy;
-  extensions = {};
-  opts.extensions.forEach(function(ext) {
-    extensions[ext] = 1;
-  });
+  setOptions(opts);
   return hbsfy;
 };
 
-module.exports = hbsfy;
+function parsePackageOptions() {
+  var response = mothership.sync(process.cwd(), function (pack) {
+    return !!pack.hbsfy;
+  });
 
+  if (response && response.pack.hbsfy) {
+    setOptions(response.pack.hbsfy);
+  }
+}
+
+function setOptions(options) {
+  if (options.extensions && Array.isArray(options.extensions)) {
+    extensions = {};
+    options.extensions.forEach(function(ext) {
+      extensions[ext] = 1;
+    });
+  }
+
+  if (options.precompiler) {
+    try {
+      precompiler = require(options.precompiler);  
+    } catch (e) {
+      throw e;
+    }
+  }
+
+  if (options.compiler) {
+    compiler = options.compiler;
+  }
+}
+
+module.exports = hbsfy;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "author": "Esa-Matti Suuronen",
   "license": "MIT",
   "dependencies": {
+    "mothership": "~0.3.0",
     "through": "~2.3.4"
   },
   "peerDependencies": {

--- a/test.sh
+++ b/test.sh
@@ -7,4 +7,5 @@ npm link hbsfy
 node test.js
 node browserify_test.js
 node custom_extension_test.js
+node package_json_test.js
 

--- a/test/browserify_test.js
+++ b/test/browserify_test.js
@@ -5,7 +5,9 @@ var assert = require("assert");
 var vm = require("vm");
 
 var b = browserify(__dirname + "/browsercode.js");
-b.transform(require("hbsfy"));
+b.transform(require("hbsfy").configure({
+  extensions: ["hbs"]
+}));
 
 // Browser mock
 var context = {

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "package-json-test",
+  "hbsfy": {
+    "extensions": ["html"]
+  }
+}

--- a/test/package_json_test.js
+++ b/test/package_json_test.js
@@ -1,0 +1,15 @@
+var assert = require("assert");
+var concat = require("concat-stream");
+var fs = require("fs");
+var hbsfy = require("hbsfy");
+
+var templatePath = __dirname + "/custom.html";
+
+fs.createReadStream(templatePath)
+.pipe(hbsfy(templatePath))
+.pipe(concat(function(data) {
+  assert(
+    /hbsfy compiled Handlebars template/.test(data.toString()),
+    "The template should be compiled"
+  );
+}));

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,9 @@
 var fs = require("fs");
 var assert = require("assert");
 
-var hbsfy = require("hbsfy");
+var hbsfy = require("hbsfy").configure({
+  extensions: ["hbs"]
+});
 var Handlebars = require("hbsfy/runtime");
 
 Handlebars.registerHelper("upcase", function(s) {


### PR DESCRIPTION
In response to issue #24. 

This allows the user to specify the following options in their `package.json` (the way browserify is doing it now):

``` json
{
  "hbsfy": {
    "extensions": ["html"],
    "precompiler": "my-precompiler-module",
    "compiler": "require('my-compiler') or window.myCompiler"
  }
}
```

`hbsfy.configure` overrides any configurations in the `package.json`, and all options are optional (hbsfy works as expected with no options).
