### PR TITLE
Allow sending options to the handlebars compiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function hbsfy(file, opts) {
     }
 
     if (opts.c || opts.compiler) {
-      compiler = opts.c || opts.compiler;  
+      compiler = opts.c || opts.compiler;
     }
   }
 
@@ -59,7 +59,7 @@ function hbsfy(file, opts) {
     buffer += chunk.toString();
   },
   function() {
-    var js = precompiler.precompile(buffer);
+    var js = precompiler.precompile(buffer, opts && opts.precompilerOptions);
     // Compile only with the runtime dependency.
     var compiled = "// hbsfy compiled Handlebars template\n";
     compiled += "var HandlebarsCompiler = " + compiler + ";\n";

--- a/test/custom_precompiler_options_test.js
+++ b/test/custom_precompiler_options_test.js
@@ -1,0 +1,33 @@
+var hbsfy        = require("hbsfy");
+var concat       = require("concat-stream");
+var assert       = require("assert");
+var fs           = require("fs");
+var templatePath = __dirname + "/hello.hbs";
+
+//let's not miss a lib change :o
+fs.createReadStream(templatePath)
+  .pipe(hbsfy(templatePath))
+  .pipe(concat(function(data) {
+    assert(
+      /helperMissing\.call/.test(data.toString()),
+      "The helperMissing call is present"
+    );
+  }));
+
+//actually check that the options were sent
+//knownHelpers => all the helperMissing stuff shouldn't be here
+fs.createReadStream(templatePath)
+  .pipe(hbsfy(templatePath, {
+    precompilerOptions: {
+      knownHelpers: {
+        'upcase': true
+      },
+      knownHelpersOnly: true
+    }
+  }))
+  .pipe(concat(function(data) {
+    assert(
+      !/helperMissing\.call/.test(data.toString()),
+      "The helperMissing call should not be present"
+    );
+  }));


### PR DESCRIPTION
just use then

``` javascript
configure({
  precompilerOptions: {
    knownHelpersOnly: true,
    knownHelpers: {
      myUltimateHelper: true
    }
  }
});
```

fixes epeli/node-hbsfy#21
