### PR TITLE
Add Handlebars to dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
   "license": "MIT",
   "dependencies": {
     "through": "~2.3.4",
+    "handlebars": "~1.3.0",
     "xtend": "~3.0.0"
   },
   "devDependencies": {
     "concat-stream": "~1.4.1",
-    "handlebars": "~1.3.0",
     "browserify": "~4.2.3"
   }
 }


### PR DESCRIPTION
Handlebars is required to run, should be in dependencies rather than dev dependencies... right?
