### PR TITLE
Auto-require and register partials (+tests)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "iojs"
+  - "node"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "iojs"

--- a/test/partial_require.hbs
+++ b/test/partial_require.hbs
@@ -1,0 +1,1 @@
+<p>{{> ./partial_required.hbs}}</p>

--- a/test/partial_require_test.js
+++ b/test/partial_require_test.js
@@ -1,0 +1,16 @@
+
+var concat = require("concat-stream");
+var browserify = require("browserify");
+var assert = require("assert");
+var vm = require("vm");
+
+var b = browserify(__dirname + "/partial_require.hbs");
+b.transform(require("hbsfy"), { traverse: true });
+
+b.bundle().pipe(concat(function(data) {
+  var bundle = data.toString();
+  assert(/require\('.\/partial_required\.hbs'\)/.test(bundle), 'looking for require');
+  assert(/partial_required.hbs['"]\:/.test(bundle), 'looking for included partial');
+  assert(/var partial\$0/.test(bundle), 'looking for partial temp var');
+  assert(/, partial\$0/.test(bundle), 'looking for partial registration');
+}));

--- a/test/partial_required.hbs
+++ b/test/partial_required.hbs
@@ -1,0 +1,1 @@
+Required


### PR DESCRIPTION
Hello! This PR adds support for implicit `require` of Handlebars partials. This way you can do something like:

```
{{> some-package/a-partial.hbs}}
```

And it will automatically be `require`ed by browserify and then registered as a partial.

Since this is a large-ish change, I completely understand if you don't want to merge this / maintain this functionality. If so, just let me know! I'll probably do some sort of hard fork (with a completely different name, of course). If you are into it, let me know and I'll add some documentation :) And of course, please let me know your general thoughts as well.

Thanks!