### PR TITLE
add processContent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,19 @@ require.extensions['.hbs'] = function (module, filename) {
 }
 ```
 
+### Process output HTML string
+
+This option accepts a function which takes one argument (the template file content) and returns a string which will be used as the source for the precompiled template object. The example below removes leading and trailing spaces to shorten templates.
+
+```
+hbsfy.configure({
+  processContent: function(content) {
+    content = content.replace(/^[\x20\t]+/mg, '').replace(/[\x20\t]+$/mg, '');
+    content = content.replace(/^[\r\n]+/, '').replace(/[\r\n]*$/, '\n');
+    return content;
+  }
+});
+```
 
 ## Changelog
 

--- a/index.js
+++ b/index.js
@@ -11,6 +11,9 @@ var defaultExtensions = {
   handlebar: true,
   handlebars: true
 };
+var defaultProcessContent = function(content) {
+  return content;
+}
 
 function findPartials(tree) {
   var partials = [];
@@ -68,6 +71,7 @@ function getOptions(opts) {
   var compiler = defaultCompiler;
   var precompiler = defaultPrecompiler;
   var traverse = defaultTraverse;
+  var processContent = defaultProcessContent;
 
   opts = opts || {};
 
@@ -87,13 +91,18 @@ function getOptions(opts) {
     if (opts.t || opts.traverse) {
       traverse = opts.t || opts.traverse;
     }
+
+    if (opts.pc || opts.processContent) {
+      processContent = opts.pc || opts.processContent;
+    }
   }
 
   return xtend({}, opts, {
     extensions: extensions,
     precompiler: precompiler,
     compiler: compiler,
-    traverse: traverse
+    traverse: traverse,
+    processContent: processContent
   });
 }
 
@@ -102,6 +111,7 @@ function compile(file, opts) {
   var compiler = options.compiler;
   var precompiler = options.precompiler;
   var traverse = options.traverse;
+  var processContent = options.processContent;
 
   var js;
   var compiled = "// hbsfy compiled Handlebars template\n";
@@ -110,6 +120,7 @@ function compile(file, opts) {
 
   // Kill BOM
   file = file.replace(/^\uFEFF/, '');
+  file = processContent(file);
 
   if (traverse) {
     parsed = precompiler.parse(file);

--- a/test/indentation.hbs
+++ b/test/indentation.hbs
@@ -1,0 +1,3 @@
+<header>
+    <h1>Hi {{name}}!</h1>
+</header>

--- a/test/indentation_test.js
+++ b/test/indentation_test.js
@@ -1,0 +1,32 @@
+/*jshint node: true*/
+
+var fs = require("fs");
+var assert = require("assert");
+
+var hbsfy = require("hbsfy");
+var Handlebars = require("hbsfy/runtime");
+
+
+var templatePath = __dirname + "/indentation.hbs";
+var exported = __dirname + "/compiled.js";
+
+try {
+  fs.unlinkSync(exported);
+} catch (err) { }
+
+fs.createReadStream(templatePath)
+.pipe(hbsfy(templatePath, {
+  processContent: function(content) {
+    return content
+      .replace(/^[\x20\t]+/mg, '')
+      .replace(/[\x20\t]+$/mg, '')
+      .replace(/[\r\n]/g, '');
+  }
+}))
+.pipe(fs.createWriteStream(exported))
+.on("close", function() {
+  var template = require(exported);
+  var res = template({ name: "Bob" });
+  assert.equal(res, "<header><h1>Hi Bob!</h1></header>");
+});
+


### PR DESCRIPTION
It removes leading and trailing spaces to shorten templates like grunt-contrib-handlebars does.
https://github.com/gruntjs/grunt-contrib-handlebars#processcontent