### PR TITLE
Support partial block statements with --traverse

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function findPartials(tree) {
   var partials = [];
   hbTraverse(tree, function(node) {
     // handlebars 3,4
-    if (node.type === 'PartialStatement' && !inlinePartials[node.name.original]) {
+    if ((node.type === 'PartialStatement' || node.type === 'PartialBlockStatement') && node.name.original.substr(0,1) !== "@" && !inlinePartials[node.name.original]) {
       partials.push(node.name.original);
       return
     }

--- a/test/blockPartialBrowserCode.js
+++ b/test/blockPartialBrowserCode.js
@@ -1,0 +1,5 @@
+var Handlebars = require("hbsfy/runtime");
+
+var template = require("./block_partial_require.hbs");
+
+document.body.innerHTML = template();

--- a/test/block_partial_require.hbs
+++ b/test/block_partial_require.hbs
@@ -1,0 +1,1 @@
+{{#> ./block_partial_required.hbs}}<p>inside</p>{{/./block_partial_required.hbs}}

--- a/test/block_partial_require_test.js
+++ b/test/block_partial_require_test.js
@@ -1,0 +1,26 @@
+var concat = require("concat-stream");
+var browserify = require("browserify");
+var assert = require("assert");
+var vm = require("vm");
+
+var b = browserify(__dirname + "/blockPartialBrowserCode.js");
+b.transform(require("hbsfy"), { traverse: true });
+
+var context = {
+  document: {
+    body: {}
+  }
+};
+
+b.bundle().pipe(concat(function(data) {
+  var bundle = data.toString();
+  assert(/require\('.\/block_partial_required\.hbs'\)/.test(bundle), 'looking for require');
+  assert(/block_partial_required.hbs['"]\:/.test(bundle), 'looking for included partial');
+  assert(/var partial\$0/.test(bundle), 'looking for partial temp var');
+  assert(/, partial\$0/.test(bundle), 'looking for partial registration');
+  vm.runInNewContext(bundle, context);
+}));
+
+setTimeout(function() {
+  assert.equal(context.document.body.innerHTML.trim(), "<div><p>inside</p></div>");
+}, 400);

--- a/test/block_partial_required.hbs
+++ b/test/block_partial_required.hbs
@@ -1,0 +1,1 @@
+<div>{{> @partial-block}}</div>


### PR DESCRIPTION
I'm working on a project where we'd like to utilise [Partial Blocks](http://handlebarsjs.com/partials.html#partial-block) in our templates, but we noticed that `hbsfy` would simply drop those blocks.

This PR introduces a minimal change to the traverse functionality which recognises `PartialBlockStatement`s, and ignores template names starting with an `@`, such as `@partial-block`.